### PR TITLE
[ION-938] Allow pointing our package.json to the slate-plugins fork

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+.storybook
+.github
+.dependabot
+.circleci
+scripts
+templates
+stories
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,32 @@
+const path = require('path')
+const modulePath =  path.join(__dirname, '../../')
+
+module.exports = function(grunt) {
+  const { peerDependencies } = grunt.file.readJSON("package.json")
+  const peerDeps = Object.keys(peerDependencies)
+
+  grunt.initConfig({
+    copy: {
+      deps: {
+        files: [{
+            expand: true,
+            cwd: 'node_modules/',
+            src: ['react/**', 'react-dnd/**', 'slate-react/**', 'react-dom/**'],
+            dest: path.join(__dirname, '../../')
+        }]
+      }
+    },
+    clean: peerDeps.map((folder) => path.join(process.cwd(), `node_modules/${folder}`))
+  });
+
+  grunt.registerTask('clean:deps', 'Cleaning deps tree', function() {
+    if (path.basename(modulePath) === 'node_modules') {
+      grunt.task.run('copy');
+      grunt.task.run('clean');
+    }
+  });
+
+  grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.registerTask('default', ['clean:deps']);
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,10 +15,14 @@ module.exports = {
   },
   moduleDirectories: ['node_modules'],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
+  moduleNameMapper: {
+    '@udecode/slate-plugins$': '<rootDir>packages/slate-plugins/src'
+  },
   testEnvironment: 'jsdom',
   testRegex: '(test|spec).tsx?$',
   transform: {
     '^.+\\.(t|j)sx?$': 'ts-jest',
   },
+  setupFiles: ["core-js"],
   setupFilesAfterEnv: ['<rootDir>/scripts/setupTests.ts'],
 };

--- a/lerna.json
+++ b/lerna.json
@@ -8,10 +8,10 @@
     "**fixture**"
   ],
   "includeMergedTags": true,
-  "npmClient": "yarn",
+  "npmClient": "npm",
   "packages": [
     "packages/*"
   ],
-  "useWorkspaces": true,
+  "useWorkspaces": false,
   "version": "0.66.7"
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,22 @@
 {
   "private": true,
   "license": "MIT",
+  "name": "slate-plugins",
+  "version": "0.0.1",
+  "main": "packages/slate-plugins/dist",
   "workspaces": [
     "packages/core",
     "packages/slate-plugins"
   ],
+  "files": [
+    "packages",
+    "lerna.json",
+    "Gruntfile.js"
+  ],
   "scripts": {
-    "build": "lerna run build --since",
+    "prepare": "yarn build",
+    "postinstall": "lerna bootstrap --ignore-prepublish --hoist && grunt --gruntfile Gruntfile.js",
+    "build": "lerna run build",
     "build:w": "concurrently \"yarn build:core -w\" \"yarn build:plugins -w\"",
     "build:core": "lerna exec --scope @udecode/slate-plugins-core -- yarn build",
     "build:plugins": "lerna exec --ignore @udecode/slate-plugins-core --parallel -- yarn build",
@@ -72,12 +82,15 @@
     "eslint-plugin-mdx": "^1.6.9",
     "eslint-plugin-prettier": "^3.1.4",
     "faker": "^4.1.0",
+    "grunt": "^1.3.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-clean": "^2.0.0",
     "jest": "^26.0.1",
     "lerna": "^3.20.2",
     "prettier": "^2.0.5",
-    "react": "^16.13.1",
+    "react": "^16.12.0",
     "react-docgen-typescript-loader": "^3.7.2",
-    "react-dom": "^16.13.1",
+    "react-dom": "^16.12.0",
     "react-test-renderer": "^16.13.1",
     "rollup": "^2.8.0",
     "rollup-plugin-babel": "^4.4.0",
@@ -102,7 +115,14 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
+    "lerna": "^3.20.2",
     "styled-icons": "^10.2.1"
+  },
+  "peerDependencies": {
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
+    "react-dnd": "^11.1.3",
+    "slate-react": "0.58.4"
   },
   "snyk": true
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "paths": {
+      "@udecode/slate-plugins": ["./packages/slate-plugins/src"]
+    }
   }
 }


### PR DESCRIPTION
Credit cost: 120
## Issue



## What I did



## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->