### PR TITLE
[ION-953] - Increase droppable zone to include left gutter on new editor

### DIFF
--- a/packages/slate-plugins/src/dnd/components/Selectable.styles.ts
+++ b/packages/slate-plugins/src/dnd/components/Selectable.styles.ts
@@ -9,6 +9,7 @@ export const getSelectableStyles = ({
   className,
   direction,
   isDragging,
+  isDropBlock,
   selected,
 }: SelectableStyleProps): SelectableStyles => {
   return {
@@ -26,7 +27,9 @@ export const getSelectableStyles = ({
       },
       className,
     ],
-    block: {},
+    block: {
+      paddingLeft: '24px',
+    },
     blockAndGutter: {
       paddingTop: 3,
       paddingBottom: 3,
@@ -35,10 +38,11 @@ export const getSelectableStyles = ({
       {
         position: 'absolute',
         top: 0,
-        transform: 'translateX(-100%)',
+        transform: 'translateX(0%)',
         display: 'flex',
         height: '100%',
         opacity: 0,
+        maxWidth: '22px',
       },
       classNames.gutterLeft,
     ],
@@ -78,6 +82,15 @@ export const getSelectableStyles = ({
       height: 2,
       opacity: 1,
       background: '#B4D5FF',
+      ...(['left', 'right'].includes(direction) && {
+        left: direction !== 'right' ? 0 : 'unset',
+        top: -1,
+        height: '100%',
+        width: 2,
+      }),
+    },
+    dropBlock: {
+      outline: isDropBlock ? '1px solid #B4D5FF' : undefined,
     },
   };
 };

--- a/packages/slate-plugins/src/dnd/components/Selectable.tsx
+++ b/packages/slate-plugins/src/dnd/components/Selectable.tsx
@@ -29,9 +29,9 @@ const SelectableBase = ({
   const rootRef = useRef<HTMLDivElement>(null);
   const multiRootRef = useMergedRef(componentRef, rootRef);
 
-  const { dropLine, dragRef, isDragging } = useDndBlock({
+  const { dropLine, dragRef, isDragging, isDropBlock } = useDndBlock({
     id: element.id,
-    blockRef,
+    blockRef: rootRef,
   });
 
   const dragWrapperRef = useRef(null);
@@ -41,13 +41,18 @@ const SelectableBase = ({
     className,
     direction: dropLine,
     isDragging,
+    isDropBlock,
   });
 
   return (
     <div className={classNames.root} ref={multiRootRef}>
       <div
         ref={blockRef}
-        className={mergeStyles(classNames.blockAndGutter, classNames.block)}
+        className={mergeStyles(
+          classNames.blockAndGutter,
+          classNames.block,
+          classNames.dropBlock
+        )}
       >
         {children}
 

--- a/packages/slate-plugins/src/dnd/components/Selectable.types.ts
+++ b/packages/slate-plugins/src/dnd/components/Selectable.types.ts
@@ -28,8 +28,9 @@ export interface SelectableProps
 
 export interface SelectableStyleProps {
   className?: string;
-  direction: '' | 'top' | 'bottom';
+  direction: '' | 'top' | 'bottom' | 'left' | 'right';
   isDragging: boolean;
+  isDropBlock?: boolean;
 
   // TODO: tbd
   selected?: boolean;
@@ -82,6 +83,11 @@ export interface SelectableStyles {
    * Show a dropline above or below the block when dragging a block.
    */
   dropLine?: IStyle;
+
+  /**
+   * Show a dropZone around a block.
+   */
+  dropBlock?: IStyle;
 }
 
 export interface DragItemBlock {
@@ -89,4 +95,10 @@ export interface DragItemBlock {
   type: string;
 }
 
-export type DropDirection = 'top' | 'bottom' | undefined;
+export type DropDirection =
+  | 'top'
+  | 'bottom'
+  | 'left'
+  | 'right'
+  | 'inside'
+  | undefined;

--- a/packages/slate-plugins/src/dnd/hooks/useDndBlock.ts
+++ b/packages/slate-plugins/src/dnd/hooks/useDndBlock.ts
@@ -13,7 +13,9 @@ export const useDndBlock = ({
 }) => {
   const editor = useEditor() as ReactEditor & ToggleTypeEditor;
 
-  const [dropLine, setDropLine] = useState<'' | 'top' | 'bottom'>('');
+  const [dropLine, setDropLine] = useState<
+    '' | 'top' | 'bottom' | 'inside' | 'left' | 'right'
+  >('');
 
   const [{ isDragging }, dragRef, preview] = useDragBlock(editor, id);
   const [{ isOver }, drop] = useDropBlockOnEditor(editor, {
@@ -31,7 +33,8 @@ export const useDndBlock = ({
 
   return {
     isDragging,
-    dropLine,
+    dropLine: dropLine !== 'inside' ? dropLine : '',
     dragRef,
+    isDropBlock: dropLine === 'inside',
   };
 };

--- a/packages/slate-plugins/src/dnd/utils/getHoverDirection.ts
+++ b/packages/slate-plugins/src/dnd/utils/getHoverDirection.ts
@@ -23,6 +23,15 @@ export const getHoverDirection = (
 
   // Get vertical middle
   const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+  const hoverMiddleX = (hoverBoundingRect.right - hoverBoundingRect.left) / 2;
+
+  const verticalSection = hoverBoundingRect.height / 3;
+  const topBoundary = hoverMiddleY - verticalSection;
+  const bottomBoundary = hoverMiddleY + verticalSection;
+
+  const horizontalSection = hoverBoundingRect.width / 3;
+  const leftBoundary = hoverMiddleX + horizontalSection;
+  const rightBoundary = hoverMiddleX - horizontalSection;
 
   // Determine mouse position
   const clientOffset = monitor.getClientOffset();
@@ -31,19 +40,33 @@ export const getHoverDirection = (
   // Get pixels to the top
   const hoverClientY = (clientOffset as XYCoord).y - hoverBoundingRect.top;
 
+  const hoverClientX = hoverBoundingRect.right - (clientOffset as XYCoord).x;
+
   // Only perform the move when the mouse has crossed half of the items height
   // When dragging downwards, only move when the cursor is below 50%
   // When dragging upwards, only move when the cursor is above 50%
 
   // Dragging downwards
   // if (dragId < hoverId && hoverClientY < hoverMiddleY) {
-  if (hoverClientY < hoverMiddleY) {
+  if (hoverClientY < topBoundary) {
     return 'top';
   }
 
   // Dragging upwards
   // if (dragId > hoverId && hoverClientY > hoverMiddleY) {
-  if (hoverClientY >= hoverMiddleY) {
+  if (hoverClientY >= bottomBoundary) {
     return 'bottom';
+  }
+
+  if (hoverClientX > leftBoundary) {
+    return 'left';
+  }
+
+  if (hoverClientX < rightBoundary) {
+    return 'right';
+  }
+
+  if (hoverClientY > topBoundary && hoverClientY < bottomBoundary) {
+    return 'inside';
   }
 };

--- a/packages/slate-plugins/src/dnd/utils/getNewDirection.ts
+++ b/packages/slate-plugins/src/dnd/utils/getNewDirection.ts
@@ -1,16 +1,11 @@
 /**
  * Get new direction if updated
  */
+const allowedDirections = ['top', 'bottom', 'inside', 'left', 'right']
 export const getNewDirection = (previousDir: string, dir?: string) => {
   if (!dir && previousDir) {
     return '';
   }
 
-  if (dir === 'top' && previousDir !== 'top') {
-    return 'top';
-  }
-
-  if (dir === 'bottom' && previousDir !== 'bottom') {
-    return 'bottom';
-  }
+  if (dir && allowedDirections.includes(dir) && dir !== previousDir) return dir;
 };


### PR DESCRIPTION
## Issue
- Fixes issue with column drag and drop
- Add gutter to left and right of block and around block



## What I did



## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->